### PR TITLE
Set filetype to rst for CMake help docs

### DIFF
--- a/autoload/cmakecomplete.vim
+++ b/autoload/cmakecomplete.vim
@@ -79,7 +79,7 @@ function cmakecomplete#Help(...)
   setlocal noswapfile
   setlocal bufhidden=delete
   silent 0put=output
-  let &filetype = 'help'
+  let &filetype = 'rst'
   setlocal nomodifiable
   0
 endfunction


### PR DESCRIPTION
CMake's help files are written using reStructuredText markup so use the rst filetype when displaying help docs in cmake help buffer.